### PR TITLE
Support keyword of `for` in auto-indent

### DIFF
--- a/lib/rib/extra/autoindent.rb
+++ b/lib/rib/extra/autoindent.rb
@@ -38,6 +38,7 @@ module Rib; module Autoindent
     /^class\b/         => /^(end)\b/                ,
     /^module\b/        => /^(end)\b/                ,
     /^while\b/         => /^(end)\b/                ,
+    /^for\b/           => /^(end)\b/                ,
     /^until\b/         => /^(end)\b/                ,
     # consider cases:
     # 'do

--- a/test/extra/test_autoindent.rb
+++ b/test/extra/test_autoindent.rb
@@ -125,6 +125,13 @@ describe Rib::Autoindent do
     le('end'           , 0)
   end
 
+  would 'for end' do
+    ri('for x in 1..2' , 1)
+    ri(  'if true'     , 2)
+    le(  'end'         , 1)
+    le('end'           , 0)
+  end
+
   would 'until end' do
     ri('until true'    , 1)
     ri(  'if true'     , 2)


### PR DESCRIPTION
## Before
### with `do`
<img width="209" alt="capture d ecran 2018-06-01 a 20 58 32" src="https://user-images.githubusercontent.com/8204936/40839750-bd3197e6-65de-11e8-9b93-4da140577c36.png">

### without `do`
<img width="284" alt="capture d ecran 2018-06-01 a 20 56 41" src="https://user-images.githubusercontent.com/8204936/40839772-d09ea33c-65de-11e8-92f9-5b85d3c724fc.png">


## After
### with `do`
 -> the same result as before 

### without `do`
<img width="202" alt="capture d ecran 2018-06-01 a 20 57 40" src="https://user-images.githubusercontent.com/8204936/40839767-c9869852-65de-11e8-82c9-52be76e7e5b4.png">

