### PR TITLE
add parentheses to auto-indent

### DIFF
--- a/lib/rib/extra/autoindent.rb
+++ b/lib/rib/extra/autoindent.rb
@@ -54,6 +54,7 @@ module Rib; module Autoindent
     # begin
     /do( *\|.*\|)?$/ => /^(end)\b/                ,
     /\{( *\|.*\|)?$/ => /^(\})\B/                 ,
+    /\($/            => /^(\))\B/                 ,
     # those are too hard to deal with, so we use syntax error to double check
     # what about this then?
     # v = if true


### PR DESCRIPTION
## Note
I see gem`pry` supports parentheses with line break.
I'm not sure whether this implementation is your taste or not.
And I don't know the proper way to add a test to it because apparently there is no existing test for braces.

## Before
<img width="319" alt="capture d ecran 2018-06-01 a 23 07 00" src="https://user-images.githubusercontent.com/8204936/40845605-3161f008-65f2-11e8-98c6-a52da9fc8ee4.png">

## After
<img width="309" alt="capture d ecran 2018-06-01 a 23 05 28" src="https://user-images.githubusercontent.com/8204936/40845619-3b576c32-65f2-11e8-8947-90bc9f8e83d0.png">
