### PR TITLE
add square brackets to auto-indent

### DIFF
--- a/lib/rib/extra/autoindent.rb
+++ b/lib/rib/extra/autoindent.rb
@@ -54,6 +54,7 @@ module Rib; module Autoindent
     # begin
     /do( *\|.*\|)?$/ => /^(end)\b/                ,
     /\{( *\|.*\|)?$/ => /^(\})\B/                 ,
+    /\[$/            => /^(\])\B/                 ,
     # those are too hard to deal with, so we use syntax error to double check
     # what about this then?
     # v = if true


### PR DESCRIPTION
## Note
I see gem`pry` supports square brackets with line break, too.
This PR is related to #19

## Before
<img width="147" alt="capture d ecran 2018-06-01 a 23 14 48" src="https://user-images.githubusercontent.com/8204936/40846107-9a02c4c4-65f3-11e8-9343-8bcf31a0dbac.png">

## After
<img width="162" alt="capture d ecran 2018-06-01 a 23 15 49" src="https://user-images.githubusercontent.com/8204936/40846113-9eb41cc0-65f3-11e8-91b2-621f2c745ddd.png">

