### PR TITLE
CI: drop unused Travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 
 install: 'gem install bundler; bundle install --retry=3'


### PR DESCRIPTION
Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration